### PR TITLE
Add support for extend in tsconfig

### DIFF
--- a/test/fixtures/read-tsconfig/tsconfig.json
+++ b/test/fixtures/read-tsconfig/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "target": "es2020",
     "module": "esnext",
-    "strict": true,
     "jsx": "preserve",
     "jsxFactory": "customJsxFactory",
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "skipLibCheck": true,
-    "noUnusedLocals": true,
-    "noImplicitAny": true,
-    "allowJs": true,
-    "resolveJsonModule": true,
     "experimentalDecorators": true
   }
 }


### PR DESCRIPTION
Adding support for extends in tsconfig. In the case of a monorepo it is necessary to resolve the parent configurations.